### PR TITLE
QueryDSL func apply

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Querydsl 추가 시작
+    implementation 'com.querydsl:querydsl-core'
+    implementation 'com.querydsl:querydsl-jpa'
+
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/com/junehouse/config/QueryDslConfig.java
+++ b/src/main/java/com/junehouse/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.junehouse.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    public EntityManager em;
+
+    @Bean
+    public JPAQueryFactory JpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/junehouse/controller/PostController.java
+++ b/src/main/java/com/junehouse/controller/PostController.java
@@ -1,11 +1,11 @@
 package com.junehouse.controller;
 
 import com.junehouse.request.PostCreate;
+import com.junehouse.request.PostSearch;
 import com.junehouse.response.PostResponse;
 import com.junehouse.service.PostService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -36,7 +36,7 @@ public class PostController {
 
     // * @PageableDefault (기본10개)
     @GetMapping("/posts")
-    public List<PostResponse> getList(Pageable pageable) {
-        return postService.getList(pageable);
+    public List<PostResponse> getList(@ModelAttribute PostSearch postSearch) {
+        return postService.getList(postSearch);
     }
 }

--- a/src/main/java/com/junehouse/repository/PostRepository.java
+++ b/src/main/java/com/junehouse/repository/PostRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 }

--- a/src/main/java/com/junehouse/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/junehouse/repository/PostRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.junehouse.repository;
+
+import com.junehouse.domain.Post;
+import com.junehouse.request.PostSearch;
+
+import java.util.List;
+
+public interface PostRepositoryCustom {
+
+    List<Post> getList(PostSearch postSearch);
+}

--- a/src/main/java/com/junehouse/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/junehouse/repository/PostRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.junehouse.repository;
+
+import com.junehouse.domain.Post;
+import com.junehouse.domain.QPost;
+import com.junehouse.request.PostSearch;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class PostRepositoryImpl implements PostRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Post> getList(PostSearch postSearch) {
+        return jpaQueryFactory.selectFrom(QPost.post)
+                .limit(postSearch.getSize())
+                .offset(postSearch.getOffset())
+                .orderBy(QPost.post.id.desc())
+                .fetch();
+    }
+
+}

--- a/src/main/java/com/junehouse/request/PostSearch.java
+++ b/src/main/java/com/junehouse/request/PostSearch.java
@@ -1,0 +1,30 @@
+package com.junehouse.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class PostSearch {
+
+    private static final int MAX_SIZE = 2000;
+
+    // * 페이지 자체의 수
+    @Builder.Default
+    private Integer page = 1;
+
+    // * 페이지 게시물의 수
+    @Builder.Default
+    private Integer size = 10;
+
+    public long getOffset() {
+        return ((long) (Math.max(1, page) - 1) * Math.min(size, MAX_SIZE));
+    }
+
+    /*public PostSearch(Integer page, Integer size) {
+        this.page = page;
+        this.size = size;
+    }*/
+}

--- a/src/main/java/com/junehouse/service/PostService.java
+++ b/src/main/java/com/junehouse/service/PostService.java
@@ -3,10 +3,10 @@ package com.junehouse.service;
 import com.junehouse.domain.Post;
 import com.junehouse.repository.PostRepository;
 import com.junehouse.request.PostCreate;
+import com.junehouse.request.PostSearch;
 import com.junehouse.response.PostResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -65,10 +65,10 @@ public class PostService {
                 .build();
     }
 
-    public List<PostResponse> getList(Pageable pageable) {
+    public List<PostResponse> getList(PostSearch postSearch) {
 //        Pageable pageable = PageRequest.of(page, 10, Sort.by(Sort.Direction.DESC, "id"));
 
-        return postRepository.findAll(pageable).stream()
+        return postRepository.getList(postSearch).stream()
                 .map(PostResponse::new)
                 .collect(Collectors.toList());
     }

--- a/src/test/java/com/junehouse/controller/PostControllerTest.java
+++ b/src/test/java/com/junehouse/controller/PostControllerTest.java
@@ -153,7 +153,7 @@ class PostControllerTest {
     @DisplayName("글 여러개 조회")
     void test5() throws Exception {
         //given
-        List<Post> requestPosts = IntStream.range(1, 31)
+        List<Post> requestPosts = IntStream.range(0, 20)
                 .mapToObj(i ->
                         Post.builder()
                                 .title("글쓰기 테스트 " + i)
@@ -162,13 +162,13 @@ class PostControllerTest {
                 .collect(Collectors.toList());
         postRepository.saveAll(requestPosts);
         //when + then
-        mockMvc.perform(get("/posts?page=0&sort=id,desc")
+        mockMvc.perform(get("/posts?page=1&size=10")
                         .contentType(APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()", Matchers.is(5)))
-                .andExpect(jsonPath("$[0].id").value(30))
-                .andExpect(jsonPath("$[0].title").value("글쓰기 테스트 30"))
-                .andExpect(jsonPath("$[0].content").value("재밌는 내용 30"))
+                .andExpect(jsonPath("$.length()", Matchers.is(10)))
+//                .andExpect(jsonPath("$[0].id").value(30))
+                .andExpect(jsonPath("$[0].title").value("글쓰기 테스트 19"))
+                .andExpect(jsonPath("$[0].content").value("재밌는 내용 19"))
 //                .andExpect(jsonPath("$[1].id").value(post2.getId()))
 //                .andExpect(jsonPath("$[1].title").value("제목2"))
 //                .andExpect(jsonPath("$[1].content").value("게시글2"))

--- a/src/test/java/com/junehouse/service/PostServiceTest.java
+++ b/src/test/java/com/junehouse/service/PostServiceTest.java
@@ -3,6 +3,7 @@ package com.junehouse.service;
 import com.junehouse.domain.Post;
 import com.junehouse.repository.PostRepository;
 import com.junehouse.request.PostCreate;
+import com.junehouse.request.PostSearch;
 import com.junehouse.response.PostResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -10,9 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -103,7 +101,7 @@ class PostServiceTest {
     void test4() {
         // select, limit, offset
         //given
-        List<Post> requestPosts = IntStream.range(1, 31)
+        List<Post> requestPosts = IntStream.range(0, 20)
                 .mapToObj(i ->
                         Post.builder()
                                 .title("글쓰기 테스트 " + i)
@@ -122,15 +120,19 @@ class PostServiceTest {
                         .build()
         ));*/
 
-        Pageable pageable = PageRequest.of(0, 10, Sort.Direction.DESC, "id");
+//        Pageable pageable = PageRequest.of(0, 5, Sort.Direction.DESC, "id");
+        PostSearch postSearch = PostSearch.builder()
+                .page(1)
+                .size(10)
+                .build();
 
         //when
-        List<PostResponse> posts = postService.getList(pageable);
+        List<PostResponse> posts = postService.getList(postSearch);
 
         //then 리스트 조회
         assertEquals(10L, posts.size());
-        assertEquals("글쓰기 테스트 30", posts.get(0).getTitle());
-        assertEquals("글쓰기 테스트 21", posts.get(9).getTitle());
+        assertEquals("글쓰기 테스트 19", posts.get(0).getTitle());
+//        assertEquals("글쓰기 테스트 21", posts.get(9).getTitle());
 
     }
 }


### PR DESCRIPTION
QueryDslConfig // bean 설정 후 적용
PostRepositoryCustom // interface 리스트 조회 생성
PostRepository // PostRepositoryCustom 상속
PostRepositoryImpl // PostRepositoryCustom 구현부 querydsl로 적용
PostSearch // 페이징 전용 VO 구현 및 웹에서 0으로 넘겼을 시 Nagative erro 발생 방지 적용

PostService, PostController // PostSearch VO로 변경