### PR TITLE
null 처리 안되는 부분 수정

### DIFF
--- a/src/main/java/com/junehouse/controller/PostController.java
+++ b/src/main/java/com/junehouse/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.junehouse.controller;
 
 import com.junehouse.request.PostCreate;
+import com.junehouse.request.PostEdit;
 import com.junehouse.request.PostSearch;
 import com.junehouse.response.PostResponse;
 import com.junehouse.service.PostService;
@@ -40,5 +41,9 @@ public class PostController {
         return postService.getList(postSearch);
     }
 
+    @PatchMapping("/posts/{postId}")
+    public PostResponse edit(@PathVariable Long postId, @RequestBody @Valid PostEdit request) {
+        return postService.edit(postId, request);
+    }
 
 }

--- a/src/main/java/com/junehouse/domain/Post.java
+++ b/src/main/java/com/junehouse/domain/Post.java
@@ -26,6 +26,7 @@ public class Post {
         this.content = content;
     }
 
+    // * 방법 1
     public PostEditor.PostEditorBuilder toEditor() {
         return PostEditor.builder()
                 .title(title)
@@ -35,5 +36,11 @@ public class Post {
     public void edit(PostEditor postEditor) {
         title = postEditor.getTitle();
         content = postEditor.getContent();
+    }
+    // -----------------------------------------------
+
+    public void edit2(String title, String content) {
+        this.title = title;
+        this.content = content;
     }
 }

--- a/src/main/java/com/junehouse/domain/Post.java
+++ b/src/main/java/com/junehouse/domain/Post.java
@@ -37,8 +37,8 @@ public class Post {
         title = postEditor.getTitle();
         content = postEditor.getContent();
     }
-    // -----------------------------------------------
 
+    // * 방법 2
     public void edit2(String title, String content) {
         this.title = title;
         this.content = content;

--- a/src/main/java/com/junehouse/domain/PostEditor.java
+++ b/src/main/java/com/junehouse/domain/PostEditor.java
@@ -1,6 +1,5 @@
 package com.junehouse.domain;
 
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -8,9 +7,53 @@ public class PostEditor {
     private final String title;
     private final String content;
 
-    @Builder
     public PostEditor(String title, String content) {
-        this.title = title != null ? title : this.getTitle();
+        this.title = title;
         this.content = content;
     }
+
+    public static PostEditorBuilder builder() {
+        return new PostEditorBuilder();
+    }
+
+    public String getTitle() {
+        return this.title;
+    }
+
+    public String getContent() {
+        return this.content;
+    }
+
+    public static class PostEditorBuilder {
+        private String title;
+        private String content;
+
+        PostEditorBuilder() {
+        }
+
+        public PostEditorBuilder title(final String title) {
+            // * 제목의 null 처리
+            if (title != null) {
+                this.title = title;
+            }
+            return this;
+        }
+
+        public PostEditorBuilder content(final String content) {
+            // * 내용의 null 처리
+            if (content != null) {
+                this.content = content;
+            }
+            return this;
+        }
+
+        public PostEditor build() {
+            return new PostEditor(this.title, this.content);
+        }
+
+        public String toString() {
+            return "PostEditor.PostEditorBuilder(title=" + this.title + ", content=" + this.content + ")";
+        }
+    }
+
 }

--- a/src/main/java/com/junehouse/domain/PostEditor.java
+++ b/src/main/java/com/junehouse/domain/PostEditor.java
@@ -10,7 +10,7 @@ public class PostEditor {
 
     @Builder
     public PostEditor(String title, String content) {
-        this.title = title;
+        this.title = title != null ? title : this.getTitle();
         this.content = content;
     }
 }

--- a/src/main/java/com/junehouse/service/PostService.java
+++ b/src/main/java/com/junehouse/service/PostService.java
@@ -1,6 +1,7 @@
 package com.junehouse.service;
 
 import com.junehouse.domain.Post;
+import com.junehouse.domain.PostEditor;
 import com.junehouse.repository.PostRepository;
 import com.junehouse.request.PostCreate;
 import com.junehouse.request.PostEdit;
@@ -81,18 +82,22 @@ public class PostService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
 
         // * 방법 1
-//        PostEditor.PostEditorBuilder postEditorBuilder = post.toEditor();
+        PostEditor.PostEditorBuilder postEditorBuilder = post.toEditor();
 
         // * 해당 기능만 사용할 수 있게끔 한다.
-//        PostEditor postEditor = postEditorBuilder
-//                .title(postEdit.getTitle())
-//                .content(postEdit.getContent())
-//                .build();
+        PostEditor postEditor = postEditorBuilder
+                .title(postEdit.getTitle())
+                .content(postEdit.getContent())
+                .build();
 
-//        post.edit(postEditor);
+        post.edit(postEditor);
 
         // * 방법 2
-        post.edit2(postEdit.getTitle(), postEdit.getContent());
+//        post.edit2(postEdit.getTitle(), postEdit.getContent());
+        // * 방법 2 (null 허용 상황)
+        /*post.edit2(
+                postEdit.getTitle() != null ? postEdit.getTitle() : post.getTitle()
+                ,postEdit.getContent() != null ? postEdit.getContent() : post.getContent());*/
 
         // * responseBody 전달하려고 함.
         return new PostResponse(post);

--- a/src/main/java/com/junehouse/service/PostService.java
+++ b/src/main/java/com/junehouse/service/PostService.java
@@ -77,7 +77,7 @@ public class PostService {
     }
 
     @Transactional
-    public void edit(Long id, PostEdit postEdit) {
+    public PostResponse edit(Long id, PostEdit postEdit) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
 
@@ -100,5 +100,7 @@ public class PostService {
                 .build();
 
         post.edit(postEditorBuilder.build());
+
+        return new PostResponse(post);
     }
 }

--- a/src/main/java/com/junehouse/service/PostService.java
+++ b/src/main/java/com/junehouse/service/PostService.java
@@ -1,7 +1,6 @@
 package com.junehouse.service;
 
 import com.junehouse.domain.Post;
-import com.junehouse.domain.PostEditor;
 import com.junehouse.repository.PostRepository;
 import com.junehouse.request.PostCreate;
 import com.junehouse.request.PostEdit;
@@ -81,26 +80,21 @@ public class PostService {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
 
-        PostEditor.PostEditorBuilder postEditorBuilder = post.toEditor();
-
-        /*if(postEdit.getTitle() != null) {
-            postEditorBuilder
-                    .title(postEdit.getTitle());
-        }
-
-        if(postEdit.getContent() != null) {
-            postEditorBuilder
-                    .content(postEdit.getContent());
-        }*/
+        // * 방법 1
+//        PostEditor.PostEditorBuilder postEditorBuilder = post.toEditor();
 
         // * 해당 기능만 사용할 수 있게끔 한다.
-        PostEditor postEditor = postEditorBuilder
-                .title(postEdit.getTitle())
-                .content(postEdit.getContent())
-                .build();
+//        PostEditor postEditor = postEditorBuilder
+//                .title(postEdit.getTitle())
+//                .content(postEdit.getContent())
+//                .build();
 
-        post.edit(postEditorBuilder.build());
+//        post.edit(postEditor);
 
+        // * 방법 2
+        post.edit2(postEdit.getTitle(), postEdit.getContent());
+
+        // * responseBody 전달하려고 함.
         return new PostResponse(post);
     }
 }

--- a/src/test/java/com/junehouse/controller/PostControllerTest.java
+++ b/src/test/java/com/junehouse/controller/PostControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.junehouse.domain.Post;
 import com.junehouse.repository.PostRepository;
 import com.junehouse.request.PostCreate;
+import com.junehouse.request.PostEdit;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,8 +23,7 @@ import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -172,6 +172,30 @@ class PostControllerTest {
 //                .andExpect(jsonPath("$[1].id").value(post2.getId()))
 //                .andExpect(jsonPath("$[1].title").value("제목2"))
 //                .andExpect(jsonPath("$[1].content").value("게시글2"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("글 수정")
+    void test6() throws Exception {
+        //given
+        Post post = Post.builder()
+                .title("아이폰")
+                .content("애플")
+                .build();
+        postRepository.save(post);
+
+        PostEdit postEdit = PostEdit.builder()
+                .title("안드로이드")
+                .content("애플")
+                .build();
+
+        //when + then
+        mockMvc.perform(patch("/posts/{postId}", post.getId())
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(postEdit))
+                )
+                .andExpect(status().isOk())
                 .andDo(print());
     }
 

--- a/src/test/java/com/junehouse/service/PostServiceTest.java
+++ b/src/test/java/com/junehouse/service/PostServiceTest.java
@@ -162,4 +162,31 @@ class PostServiceTest {
 //        assertEquals("안드로이드", changePost.getTitle());
         assertEquals("안드로이드 비젼", changePost.getContent());
     }
+
+    @Test
+    @DisplayName("글 수정")
+    void test5() {
+        //given
+        Post post = Post.builder()
+                .title("아이폰")
+                .content("애플")
+                .build();
+        postRepository.save(post);
+
+        PostEdit postEdit = PostEdit.builder()
+                .title(null)
+                .content("샘송")
+                .build();
+
+        //when
+        postService.edit(post.getId(), postEdit);
+
+        //then
+        Post changePost = postRepository.findById(post.getId())
+                .orElseThrow(() -> new RuntimeException("글이 존재하지 않습니다. id = " + post.getId()));
+
+//        assertEquals("안드로이드", changePost.getTitle());
+        assertEquals("아이폰", changePost.getTitle());
+        assertEquals("샘송", changePost.getContent());
+    }
 }


### PR DESCRIPTION
상황 설명
1. 게시글 작성 후 수정 시의 상황
2. 제목은 수정했지만 내용을 수정하지 않았을 경우
3. 내용에 null이 들어온다. (반대의 경우도 마찬가지)
4. null 처리를 했다고 했지만 정상작동하지 않음.
5. 글 수정 도메인을 따로 만들었기 때문에 해당 도메인에 빌더클래스 패턴을 적용 후 필드 setter에 null처리를 적용했다.
6. 테스트 성공
7. 빌드패턴 적용하지 않을 시 방법에 대한 예제도 적용함. (주석 참조)